### PR TITLE
Questionnaire passing (slightly fixed)

### DIFF
--- a/bot/api/questionnaire.py
+++ b/bot/api/questionnaire.py
@@ -97,6 +97,7 @@ class QuestionnaireAPI:
             url=self._API_URL + send_answers_uri,
             json=answers
         )
+        await asyncio.sleep(1)
 
         get_results_uri = '/risks/result/'
         response = await requester.request(method='GET',


### PR DESCRIPTION
- In comparison to previous pull request, the 1 second delay was added between request of sending user answers from bot to API, and retrieving results.
- The problem was that due to these consecutive requests, the API responded with part of the questionnaire results (1 or 2 risk groups). When running locally there was no such issue, so the reason might be lower latency between production servers of bot and API